### PR TITLE
update for jdk7 compatibility

### DIFF
--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/JenkinsConfigurationException.java
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/JenkinsConfigurationException.java
@@ -1,4 +1,4 @@
-package com.terrafolio.gradle.plugins.jenkins
+package com.terrafolio.gradle.plugins.jenkins;
 
 class JenkinsConfigurationException extends Exception {
 
@@ -18,5 +18,4 @@ class JenkinsConfigurationException extends Exception {
 		super(arg0);
 	}
 
-	
 }


### PR DESCRIPTION
When I first tried to use the plugin, I ran into an incompatibility with jdk7 (see this post for details - http://blog.proxerd.pl/article/how-to-fix-incompatibleclasschangeerror-for-your-groovy-projects-running-on-jdk7).

This update just converts JenkinsConfigurationException from .groovy to .java.

Thanks for creating this, programmatically maintaining templated job configurations is so much better!
