### PR TITLE
Replace publishing logic with nexus plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,6 @@ apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'nexus'
 
-group = 'com.terrafolio'
-
 repositories {
 	addAll(buildscript.repositories)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 version=1.0.0
+group=com.terrafolio


### PR DESCRIPTION
In order to install the jar for internal testing, I was required to supply a sonatypeUsername/sonatypePassword. I took this opportunity to replace this handcrafted logic with the gradle-nexus-plugin: https://github.com/bmuschko/gradle-nexus-plugin

I'll let you know how internal testing of the jenkins-job-dsl goes for me.
