### PR TITLE
Upgraded to the new 1.25 release of the job-dsl-plugin and extended the ViewDSLSupport class to cover Nested and Sectioned views. Added further stubs to the MapJobManagement.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     compile('org.codehaus.groovy.modules.http-builder:http-builder:0.5.2') {
         exclude(module: 'groovy')
     }
-    compile('org.jenkins-ci.plugins:job-dsl-core:1.24') {
+    compile('org.jenkins-ci.plugins:job-dsl-core:1.25') {
         exclude(module: 'groovy-all')
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.2.2
+version=1.2.3
 group=com.terrafolio

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/dsl/ViewDSLSupport.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/dsl/ViewDSLSupport.groovy
@@ -3,6 +3,8 @@ package com.terrafolio.gradle.plugins.jenkins.dsl
 import javaposse.jobdsl.dsl.*
 import javaposse.jobdsl.dsl.views.BuildPipelineView
 import javaposse.jobdsl.dsl.views.ListView
+import javaposse.jobdsl.dsl.views.NestedView
+import javaposse.jobdsl.dsl.views.SectionedView
 
 /**
  * Created by ghale on 6/2/14.
@@ -13,6 +15,8 @@ class ViewDSLSupport implements DSLSupport {
     private static final Map<ViewType, Class<? extends View>> VIEW_TYPE_MAPPING = [
             (null)                      : ListView.class,
             (ViewType.ListView)         : ListView.class,
+            (ViewType.NestedView)       : NestedView.class,
+            (ViewType.SectionedView)    : SectionedView.class,
             (ViewType.BuildPipelineView): BuildPipelineView.class,
     ]
 

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/jobdsl/MapJobManagement.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/jobdsl/MapJobManagement.groovy
@@ -2,9 +2,12 @@ package com.terrafolio.gradle.plugins.jenkins.jobdsl
 
 import com.google.common.collect.Maps
 import javaposse.jobdsl.dsl.AbstractJobManagement
+import javaposse.jobdsl.dsl.ConfigFile
+import javaposse.jobdsl.dsl.ConfigFileType
 import javaposse.jobdsl.dsl.ConfigurationMissingException
 import javaposse.jobdsl.dsl.JobConfigurationNotFoundException
 import javaposse.jobdsl.dsl.NameNotProvidedException
+import hudson.util.VersionNumber
 
 /**
  * Created by ghale on 4/6/14.
@@ -31,6 +34,10 @@ class MapJobManagement extends AbstractJobManagement {
         return true
     }
 
+    String createOrUpdateConfigFile(ConfigFile configFile, boolean ignoreExisting){
+        return null
+    }
+
     @Override
     void createOrUpdateView(String viewName, String config, boolean ignoreExisting) throws NameNotProvidedException, ConfigurationMissingException {
         validateUpdateArgs(viewName, config)
@@ -44,5 +51,25 @@ class MapJobManagement extends AbstractJobManagement {
 
     @Override
     void requireMinimumPluginVersion(String pluginShortName, String version){
+    }
+
+    @Override
+    VersionNumber getPluginVersion(String pluginShortName){
+        return null
+    }
+
+    @Override
+    Integer getVSphereCloudHash(String name){
+        return null
+    }
+
+    @Override
+    String getMavenSettingsId(String settingsName){
+        return null
+    }
+
+    @Override
+    String getConfigFileId(ConfigFileType type, String name){
+        return null
     }
 }

--- a/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/ViewDSLSupportTest.groovy
+++ b/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/ViewDSLSupportTest.groovy
@@ -64,6 +64,40 @@ class ViewDSLSupportTest extends TempDirSpec {
         new Diff(ViewFixtures.LIST_DSL_VIEW_XML, support.getConfig('test')).similar()
     }
 
+    def "evaluateDSL from file creates correct XML (nestedView)" () {
+        setup:
+        File file = file("test.dsl",
+                """
+                    view(type: NestedView) {
+                        name 'test'
+                    }
+                """
+        )
+        support.jobManagement = new MapJobManagement(new HashMap<String, String>())
+        XMLUnit.setIgnoreWhitespace(true)
+
+        expect:
+        support.evaluateDSL(file) == 'test'
+        new Diff(ViewFixtures.NESTED_DSL_VIEW_XML, support.getConfig('test')).similar()
+    }
+
+    def "evaluateDSL from file creates correct XML (sectionedView)" () {
+        setup:
+        File file = file("test.dsl",
+                """
+                    view(type: SectionedView) {
+                        name 'test'
+                    }
+                """
+        )
+        support.jobManagement = new MapJobManagement(new HashMap<String, String>())
+        XMLUnit.setIgnoreWhitespace(true)
+
+        expect:
+        support.evaluateDSL(file) == 'test'
+        new Diff(ViewFixtures.SECTIONED_DSL_VIEW_XML, support.getConfig('test')).similar()
+    }
+
     def "evaluateDSL from closure creates correct XML" () {
         setup:
         Closure dsl = {
@@ -81,5 +115,7 @@ class ViewDSLSupportTest extends TempDirSpec {
         null                | ViewFixtures.LIST_DSL_VIEW_XML
         'ListView'          | ViewFixtures.LIST_DSL_VIEW_XML
         'BuildPipelineView' | ViewFixtures.BUILD_PIPELINE_VIEW_XML
+        'NestedView'        | ViewFixtures.NESTED_DSL_VIEW_XML
+        'SectionedView'     | ViewFixtures.SECTIONED_DSL_VIEW_XML
     }
 }

--- a/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/ViewFixtures.groovy
+++ b/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/ViewFixtures.groovy
@@ -34,4 +34,26 @@ class ViewFixtures {
                 <showPipelineDefinitionHeader>false</showPipelineDefinitionHeader>
             </au.com.centrumsystems.hudson.plugin.buildpipeline.BuildPipelineView>
 """
+
+    protected static final String NESTED_DSL_VIEW_XML = """
+            <hudson.plugins.nested__view.NestedView>
+                <name>nested</name>
+                <filterExecutors>false</filterExecutors>
+                <filterQueue>false</filterQueue>
+                <properties class="hudson.model.View\$PropertyList"></properties>
+                <views></views>
+            </hudson.plugins.nested__view.NestedView>
+    """
+
+    protected static final String SECTIONED_DSL_VIEW_XML = """
+            <hudson.plugins.sectioned__view.SectionedView>
+                <filterExecutors>false</filterExecutors>
+                <filterQueue>false</filterQueue>
+                <properties class="hudson.model.View\$PropertyList"/>
+                <sections/>
+            </hudson.plugins.sectioned__view.SectionedView>
+    """
 }
+
+
+


### PR DESCRIPTION
I have added in the support which includes the new views (Nested/Sectioned) i reviewed the release note for the job-dsl-plugin https://github.com/jenkinsci/job-dsl-plugin/wiki#release-notes and didn't recognize anything else that might need changing to support.

Hope this is ok.

Cheers
