### PR TITLE
Added JDK6 compatibility as this is a Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@ apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'nexus'
 
+sourceCompatibility = 1.6
+targetCompatibility = 1.6
+
 repositories {
     addAll(buildscript.repositories)
 }


### PR DESCRIPTION
Addresses the JDK7 (#52) issue, but explicitly targeting JDK6 as compatibility level. Given that Gradle 2.x is still JDK6-compatible, it is recommended that plugins keep this level of compatibility too.