### PR TITLE
Allow pretty printing for remoteJenkinsItems (default=false)

### DIFF
--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/tasks/DumpJenkinsItemsTask.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/tasks/DumpJenkinsItemsTask.groovy
@@ -19,7 +19,9 @@ class DumpJenkinsItemsTask extends AbstractDumpJenkinsItemsTask {
             if (prettyPrint) {
                 file.withWriter { fileWriter ->
                     def node = new XmlParser().parseText(item.getServerSpecificXml(server));
-                    new XmlNodePrinter(new PrintWriter(fileWriter)).print(node)
+                    def nodePrinter = new XmlNodePrinter(new PrintWriter(fileWriter))
+                    nodePrinter.preserveWhitespace = true;
+                    nodePrinter.print(node)
                 }
             } else {
                 def xml = item.getServerSpecificXml(server)

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/tasks/DumpJenkinsItemsTask.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/tasks/DumpJenkinsItemsTask.groovy
@@ -5,6 +5,7 @@ import com.terrafolio.gradle.plugins.jenkins.service.BuildDirService
 
 class DumpJenkinsItemsTask extends AbstractDumpJenkinsItemsTask {
     def prettyPrint = true
+    def prettyPrintPreserveWhitespace = false;
 
     public DumpJenkinsItemsTask() {
         super();
@@ -20,7 +21,7 @@ class DumpJenkinsItemsTask extends AbstractDumpJenkinsItemsTask {
                 file.withWriter { fileWriter ->
                     def node = new XmlParser().parseText(item.getServerSpecificXml(server));
                     def nodePrinter = new XmlNodePrinter(new PrintWriter(fileWriter))
-                    nodePrinter.preserveWhitespace = true;
+                    nodePrinter.preserveWhitespace = prettyPrintPreserveWhitespace;
                     nodePrinter.print(node)
                 }
             } else {

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/tasks/DumpRemoteJenkinsItemsTask.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/tasks/DumpRemoteJenkinsItemsTask.groovy
@@ -6,6 +6,8 @@ import com.terrafolio.gradle.plugins.jenkins.service.BuildDirService
 import com.terrafolio.gradle.plugins.jenkins.service.JenkinsService
 
 class DumpRemoteJenkinsItemsTask extends AbstractDumpJenkinsItemsTask {
+    def prettyPrint = false
+
     DumpRemoteJenkinsItemsTask() {
         description = "Dumps remote item configurations from server(s) to files."
     }
@@ -21,7 +23,14 @@ class DumpRemoteJenkinsItemsTask extends AbstractDumpJenkinsItemsTask {
 
             def file = new File(buildDir.makeAndGetDir("remotes/${server.name}/$itemTypeDir"), "${item.name}.xml")
 
-            file.write(serverStrItem)
+            if (prettyPrint) {
+                file.withWriter { fileWriter ->
+                    def node = new XmlParser().parseText(serverStrItem);
+                    new XmlNodePrinter(new PrintWriter(fileWriter)).print(node)
+                }
+            } else {
+                file.write(serverStrItem)
+            }
         }
     }
 }

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/tasks/DumpRemoteJenkinsItemsTask.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/tasks/DumpRemoteJenkinsItemsTask.groovy
@@ -7,6 +7,7 @@ import com.terrafolio.gradle.plugins.jenkins.service.JenkinsService
 
 class DumpRemoteJenkinsItemsTask extends AbstractDumpJenkinsItemsTask {
     def prettyPrint = false
+    def prettyPrintPreserveWhitespace = true;
 
     DumpRemoteJenkinsItemsTask() {
         description = "Dumps remote item configurations from server(s) to files."
@@ -27,7 +28,7 @@ class DumpRemoteJenkinsItemsTask extends AbstractDumpJenkinsItemsTask {
                 file.withWriter { fileWriter ->
                     def node = new XmlParser().parseText(serverStrItem);
                     def nodePrinter = new XmlNodePrinter(new PrintWriter(fileWriter))
-                    nodePrinter.preserveWhitespace = true;
+                    nodePrinter.preserveWhitespace = prettyPrintPreserveWhitespace;
                     nodePrinter.print(node)
                 }
             } else {

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/tasks/DumpRemoteJenkinsItemsTask.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/tasks/DumpRemoteJenkinsItemsTask.groovy
@@ -26,7 +26,9 @@ class DumpRemoteJenkinsItemsTask extends AbstractDumpJenkinsItemsTask {
             if (prettyPrint) {
                 file.withWriter { fileWriter ->
                     def node = new XmlParser().parseText(serverStrItem);
-                    new XmlNodePrinter(new PrintWriter(fileWriter)).print(node)
+                    def nodePrinter = new XmlNodePrinter(new PrintWriter(fileWriter))
+                    nodePrinter.preserveWhitespace = true;
+                    nodePrinter.print(node)
                 }
             } else {
                 file.write(serverStrItem)


### PR DESCRIPTION
When pulling the initial configuration off of an exiting jenkins it is nice to have human readable xml.