### PR TITLE
Upgrade Job-DSL dependency to 1.42

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,9 +53,11 @@ dependencies {
         exclude(module: 'xercesImpl')
     }
 
-    compile('org.jenkins-ci.plugins:job-dsl-core:1.34') {
+    compile('org.jenkins-ci.plugins:job-dsl-core:1.42') {
         exclude(module: 'groovy-all')
     }
+
+    compile 'com.google.guava:guava:19.0'
 
     testCompile('com.netflix.nebula:nebula-test:1.12.5') {
         exclude(module: 'groovy-all')

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/dsl/JenkinsJob.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/dsl/JenkinsJob.groovy
@@ -1,8 +1,8 @@
 package com.terrafolio.gradle.plugins.jenkins.dsl
 
+import com.terrafolio.gradle.plugins.jenkins.jobdsl.DSLJobType
 import groovy.xml.StreamingMarkupBuilder
 import javaposse.jobdsl.dsl.JobManagement
-import javaposse.jobdsl.dsl.JobType
 import org.gradle.util.ConfigureUtil
 
 class JenkinsJob extends AbstractJenkinsConfigurable implements DSLConfigurable, XMLConfigurable {
@@ -37,7 +37,7 @@ class JenkinsJob extends AbstractJenkinsConfigurable implements DSLConfigurable,
     }
 
     def void setType(String type) {
-        if (JobType.find(type) == null) {
+        if (DSLJobType.find(type) == null) {
             throw new JenkinsConfigurationException("${type} is not a valid jenkins-job-dsl type!")
         }
         this.type = type

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/dsl/JenkinsJobTemplate.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/dsl/JenkinsJobTemplate.groovy
@@ -1,7 +1,7 @@
 package com.terrafolio.gradle.plugins.jenkins.dsl
 
+import com.terrafolio.gradle.plugins.jenkins.jobdsl.DSLJobType
 import javaposse.jobdsl.dsl.JobManagement
-import javaposse.jobdsl.dsl.JobType
 
 /**
  * Created by ghale on 4/8/14.
@@ -24,7 +24,7 @@ class JenkinsJobTemplate implements DSLConfigurable, XMLConfigurable {
     }
 
     def void setType(String type) {
-        if (JobType.find(type) == null) {
+        if (DSLJobType.find(type) == null) {
             throw new JenkinsConfigurationException("${type} is not a valid jenkins-job-dsl type!")
         }
         this.type = type

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/jobdsl/MapJobManagement.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/jobdsl/MapJobManagement.groovy
@@ -53,7 +53,14 @@ class MapJobManagement extends AbstractJobManagement {
     }
 
     @Override
+    void logPluginDeprecationWarning(String pluginShortName, String minimumVersion) { }
+
+    @Override
     void requireMinimumPluginVersion(String pluginShortName, String version){
+    }
+
+    @Override
+    void requireMinimumPluginVersion(String pluginShortName, String version, boolean failIfMissing) {
     }
 
     @Override
@@ -105,6 +112,9 @@ class MapJobManagement extends AbstractJobManagement {
 
     @Override
     void requirePlugin(String pluginShortName) { }
+
+    @Override
+    void requirePlugin(String pluginShortName, boolean failIfMissing) { }
 
     @Override
     void requireMinimumCoreVersion(String version) { }

--- a/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/JenkinsConfigurationTest.groovy
+++ b/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/JenkinsConfigurationTest.groovy
@@ -3,7 +3,6 @@ package com.terrafolio.gradle.plugins.jenkins.test.dsl
 import com.terrafolio.gradle.plugins.jenkins.dsl.JenkinsJob
 import com.terrafolio.gradle.plugins.jenkins.dsl.JenkinsView
 import javaposse.jobdsl.dsl.NameNotProvidedException
-import javaposse.jobdsl.dsl.ViewType
 import nebula.test.ProjectSpec
 import org.custommonkey.xmlunit.Diff
 import org.custommonkey.xmlunit.XMLUnit
@@ -77,8 +76,7 @@ class JenkinsConfigurationTest extends ProjectSpec {
         def dslFile = project.file('test.dsl')
         dslFile.write("""
             for (i in 0..2) {
-                job {
-                    name "Test Job \${i}"
+                freeStyleJob("Test Job \${i}") {
                 }
             }
         """)
@@ -106,8 +104,7 @@ class JenkinsConfigurationTest extends ProjectSpec {
         def dslFile1 = new File(jenkinsDir, 'test1.dsl')
         dslFile1.write("""
             for (i in 0..2) {
-                job {
-                    name "Test Job \${i}"
+                freeStyleJob("Test Job \${i}") {
                 }
             }
         """)
@@ -115,8 +112,7 @@ class JenkinsConfigurationTest extends ProjectSpec {
         def dslFile2 = new File(jenkinsDir, 'test2.dsl')
         dslFile2.write("""
             for (i in 0..2) {
-                job {
-                    name "Another Job \${i}"
+                freeStyleJob("Another Job \${i}") {
                 }
             }
         """)
@@ -145,8 +141,7 @@ class JenkinsConfigurationTest extends ProjectSpec {
         def dslFile = project.file('test.dsl')
         dslFile.write("""
             for (i in 0..2) {
-                view(type: ListView) {
-                    name("test view \${i}")
+                listView("test view \${i}") {
                 }
             }
         """)
@@ -173,8 +168,7 @@ class JenkinsConfigurationTest extends ProjectSpec {
         def dslFile1 = new File(jenkinsDir, 'test1.dsl')
         dslFile1.write("""
             for (i in 0..2) {
-                view(type: ListView) {
-                    name "test view \${i}"
+                listView("test view \${i}") {
                 }
             }
         """)
@@ -182,8 +176,7 @@ class JenkinsConfigurationTest extends ProjectSpec {
         def dslFile2 = new File(jenkinsDir, 'test2.dsl')
         dslFile2.write("""
             for (i in 0..2) {
-                view(type: ListView) {
-                    name "another view \${i}"
+                listView("another view \${i}") {
                 }
             }
         """)
@@ -212,8 +205,7 @@ class JenkinsConfigurationTest extends ProjectSpec {
         project.jenkins {
             dsl {
                 for (i in 0..2) {
-                    job {
-                        name "Test Job ${i}"
+                    freeStyleJob("Test Job ${i}") {
                     }
                 }
             }
@@ -236,8 +228,7 @@ class JenkinsConfigurationTest extends ProjectSpec {
         project.jenkins {
             dsl {
                 for (i in 0..2) {
-                    view(type: ViewType.ListView) {
-                        name "test view ${i}"
+                    listView("test view ${i}") {
                     }
                 }
             }
@@ -254,46 +245,6 @@ class JenkinsConfigurationTest extends ProjectSpec {
         "test view 2" | EMPTY_DSL_VIEW_XML
     }
 
-    def "configure throws exeception when no job name provided with dsl closure"() {
-        when:
-        project.jenkins {
-            dsl {
-                for (i in 0..2) {
-                    job {
-                        steps {
-                            shell("echo test")
-                        }
-                    }
-                }
-            }
-        }
-
-        then:
-        thrown(NameNotProvidedException)
-    }
-
-    def "configure throws exeception when no job name provided with dsl file"() {
-        setup:
-        def dslFile = project.file('test.dsl')
-        dslFile.write("""
-            for (i in 0..9) {
-                job {
-                    steps {
-                        shell "echo test"
-                    }
-                }
-            }
-        """)
-
-        when:
-        project.jenkins {
-            dsl project.files('test.dsl')
-        }
-
-        then:
-        thrown(NameNotProvidedException)
-    }
-
     def "configure configures jobs using dsl closure with basis xml"(jobName, xml) {
         setup:
         project.jenkins {
@@ -306,9 +257,8 @@ class JenkinsConfigurationTest extends ProjectSpec {
             }
             dsl {
                 for (i in 0..2) {
-                    job {
+                    freeStyleJob("Another Job ${i}") {
                         using "Test Job"
-                        name "Another Job ${i}"
                     }
                 }
             }
@@ -329,9 +279,8 @@ class JenkinsConfigurationTest extends ProjectSpec {
         def dslFile = project.file('test.dsl')
         dslFile.write("""
             for (i in 0..2) {
-                job {
+                freeStyleJob("Another Job \${i}") {
                     using "Test Job"
-                    name "Another Job \${i}"
                 }
             }
         """)

--- a/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/JenkinsJobTemplateTest.groovy
+++ b/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/JenkinsJobTemplateTest.groovy
@@ -90,8 +90,7 @@ class JenkinsJobTemplateTest extends ProjectSpec {
         XMLUnit.setIgnoreWhitespace(true)
         def dslFile = project.file('test.dsl')
         dslFile.write("""
-            job {
-                name "\${GRADLE_JOB_NAME}"
+            freeStyleJob("\${GRADLE_JOB_NAME}") {
             }
         """)
 
@@ -117,7 +116,7 @@ class JenkinsJobTemplateTest extends ProjectSpec {
             templates {
                 test {
                     dsl {
-                        name "Test Job"
+                        name = "Test Job"
                     }
                 }
             }

--- a/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/JenkinsJobTest.groovy
+++ b/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/JenkinsJobTest.groovy
@@ -68,8 +68,7 @@ class JenkinsJobTest extends ProjectSpec {
         XMLUnit.setIgnoreWhitespace(true)
         def dslFile = project.file('test.dsl')
         dslFile.write("""
-            job {
-                name "\${GRADLE_JOB_NAME}"
+            freeStyleJob("\${GRADLE_JOB_NAME}") {
             }
         """)
 
@@ -95,7 +94,7 @@ class JenkinsJobTest extends ProjectSpec {
             jobs {
                 test {
                     dsl {
-                        name "Test Job"
+                        name = "Test Job"
                     }
                 }
             }
@@ -115,7 +114,7 @@ class JenkinsJobTest extends ProjectSpec {
                 test {
                     type 'Freeform'
                     dsl {
-                        name "Test Job"
+                        name = "Test Job"
                     }
                 }
             }
@@ -135,7 +134,7 @@ class JenkinsJobTest extends ProjectSpec {
                 test {
                     type 'Maven'
                     dsl {
-                        name "Test Job"
+                        name = "Test Job"
                     }
                 }
             }
@@ -155,7 +154,7 @@ class JenkinsJobTest extends ProjectSpec {
                 test {
                     type 'Multijob'
                     dsl {
-                        name "Test Job"
+                        name = "Test Job"
                     }
                 }
             }
@@ -175,7 +174,7 @@ class JenkinsJobTest extends ProjectSpec {
                 test {
                     type 'BuildFlow'
                     dsl {
-                        name "Test Job"
+                        name = "Test Job"
                     }
                 }
             }
@@ -224,8 +223,7 @@ class JenkinsJobTest extends ProjectSpec {
         def newXml = JobFixtures.FREEFORM_DSL_JOB_XML.replaceFirst('true', 'false')
         def dslFile = project.file('test.dsl')
         dslFile.write("""
-            job {
-                name "\${GRADLE_JOB_NAME}"
+            freeStyleJob("\${GRADLE_JOB_NAME}") {
             }
         """)
 
@@ -384,8 +382,7 @@ class JenkinsJobTest extends ProjectSpec {
         def newXml = JobFixtures.FREEFORM_DSL_JOB_XML.replaceFirst('false', 'true').replaceFirst('n><', 'n>test<')
         def dslFile = project.file('test.dsl')
         dslFile.write("""
-            job {
-                name "\${GRADLE_JOB_NAME}"
+            freeStyleJob("\${GRADLE_JOB_NAME}") {
                 using "\${GRADLE_JOB_NAME}"
                 keepDependencies true
             }
@@ -418,8 +415,7 @@ class JenkinsJobTest extends ProjectSpec {
         def newXml = JobFixtures.FREEFORM_DSL_JOB_XML.replaceFirst('false', 'true').replaceFirst('n><', 'n>test<')
         def dslFile = project.file('test.dsl')
         dslFile.write("""
-            job {
-                name "\${GRADLE_JOB_NAME}"
+            freeStyleJob("\${GRADLE_JOB_NAME}") {
                 using "\${GRADLE_JOB_NAME}"
                 keepDependencies true
             }
@@ -446,8 +442,7 @@ class JenkinsJobTest extends ProjectSpec {
         def dslFile = project.file('test.dsl')
         dslFile.write("""
             for (i in 0..1) {
-                job {
-                    name "Test Job \${i}"
+                freeStyleJob("Test Job \${i}") {
                 }
             }
         """)
@@ -474,7 +469,7 @@ class JenkinsJobTest extends ProjectSpec {
             jobs {
                 test {
                     dsl {
-                        name "Test Job"
+                        name = "Test Job"
                         wrappers {
                             configure { root ->
                                 count++

--- a/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/JenkinsViewTest.groovy
+++ b/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/JenkinsViewTest.groovy
@@ -27,7 +27,7 @@ class JenkinsViewTest extends ProjectSpec {
                     type viewType
                 }
                 dsl {
-                    name "test"
+                    name = "test"
                 }
             }
         }
@@ -47,8 +47,7 @@ class JenkinsViewTest extends ProjectSpec {
         XMLUnit.setIgnoreWhitespace(true)
         def dslFile = project.file('test.dsl')
         dslFile.write("""
-            view(type: ListView) {
-                name "test"
+            listView("test") {
             }
         """)
 
@@ -68,11 +67,9 @@ class JenkinsViewTest extends ProjectSpec {
         XMLUnit.setIgnoreWhitespace(true)
         def dslFile = project.file('test.dsl')
         dslFile.write("""
-                view {
-                    name "Test View 1"
+                listView("Test View 1") {
                 }
-                view {
-                    name "Test View 2"
+                listView("Test View 2") {
                 }
         """)
 
@@ -175,7 +172,7 @@ class JenkinsViewTest extends ProjectSpec {
         project.jenkins.views {
             test {
                 dsl {
-                    name "test"
+                    name = "test"
                 }
                 xml override { viewXml ->
                     viewXml.filterExecutors = 'true'
@@ -193,8 +190,7 @@ class JenkinsViewTest extends ProjectSpec {
         def newXml = ViewFixtures.LIST_DSL_VIEW_XML.replaceFirst('false', 'true')
         def dslFile = project.file('test.dsl')
         dslFile.write("""
-            view(type: ListView) {
-                name "test"
+            listView("test") {
             }
         """)
 

--- a/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/JobDSLSupportTest.groovy
+++ b/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/JobDSLSupportTest.groovy
@@ -51,8 +51,7 @@ class JobDSLSupportTest extends TempDirSpec {
         setup:
         File file = file("test.dsl",
                 """
-                    job {
-                        name "test"
+                    freeStyleJob("test") {
                     }
                 """
         )
@@ -67,7 +66,7 @@ class JobDSLSupportTest extends TempDirSpec {
     def "evaluateDSL from closure creates correct XML" (String type, String expectedXml) {
         setup:
         Closure dsl = {
-            name "test"
+            name = "test"
         }
         support.jobManagement = new MapJobManagement(new HashMap<String, String>())
         XMLUnit.setIgnoreWhitespace(true)

--- a/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/ViewDSLSupportTest.groovy
+++ b/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/ViewDSLSupportTest.groovy
@@ -51,8 +51,7 @@ class ViewDSLSupportTest extends TempDirSpec {
         setup:
         File file = file("test.dsl",
                 """
-                    view {
-                        name "test"
+                    listView("test") {
                     }
                 """
         )
@@ -68,8 +67,7 @@ class ViewDSLSupportTest extends TempDirSpec {
         setup:
         File file = file("test.dsl",
                 """
-                    view(type: NestedView) {
-                        name 'test'
+                    nestedView("test") {
                     }
                 """
         )
@@ -85,8 +83,7 @@ class ViewDSLSupportTest extends TempDirSpec {
         setup:
         File file = file("test.dsl",
                 """
-                    view(type: SectionedView) {
-                        name 'test'
+                    sectionedView("test") {
                     }
                 """
         )
@@ -101,7 +98,7 @@ class ViewDSLSupportTest extends TempDirSpec {
     def "evaluateDSL from closure creates correct XML" () {
         setup:
         Closure dsl = {
-            name "test"
+            name = "test"
         }
         support.jobManagement = new MapJobManagement(new HashMap<String, String>())
         XMLUnit.setIgnoreWhitespace(true)

--- a/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/tasks/UpdateJenkinsItemsTaskTest.groovy
+++ b/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/tasks/UpdateJenkinsItemsTaskTest.groovy
@@ -107,6 +107,8 @@ class UpdateJenkinsItemsTaskTest extends JenkinsPluginTaskSpec {
                       <properties class="hudson.model.View\$PropertyList"/>
                       <jobNames class="tree-set">
                         <comparator class="hudson.util.CaseInsensitiveComparator"/>
+                        <string>execute-skips-view-update-when-there-are-no-changes compile (develop)</string>
+                        <string>execute-skips-view-update-when-there-are-no-changes compile (master)</string>
                       </jobNames>
                       <jobFilters/>
                       <columns/>


### PR DESCRIPTION
Replace job with freeStyleJob and view with listView in most tests.

Remove tests that check for an exception to be thrown when no job name is
provided, since the new Job DSL syntax requires the job name as a
parameter. Also the name method does not exist in Job DSL anymore, so
replace usages with calls to the setter method for name.

javaposse.jobdsl.dsl.JobType was removed, so instead use the simlar class
com.terrafolio.gradle.plugins.jenkins.jobdsl.DSLJobType.