### PR TITLE
Allow integration tests to work under windows

### DIFF
--- a/src/integTest/groovy/com/terrafolio/gradle/plugins/jenkins/integTest/AbstractJenkinsIntegrationTest.groovy
+++ b/src/integTest/groovy/com/terrafolio/gradle/plugins/jenkins/integTest/AbstractJenkinsIntegrationTest.groovy
@@ -12,7 +12,7 @@ abstract class AbstractJenkinsIntegrationTest extends IntegrationSpec {
         buildFile << """
             buildscript {
                 dependencies {
-                    classpath files('${System.getProperty('jenkins.plugin')}')
+                    classpath files('${System.getProperty('jenkins.plugin').replaceAll("\\\\", "/")}')
                 }
             }
 


### PR DESCRIPTION
The integration tests do not pass when building under windows. This fix allows them to pass.