### PR TITLE
Bump JobDSL to 1.50

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
     dependencies {
         classpath 'org.gradle.api.plugins:gradle-nexus-plugin:0.7'
         classpath "com.gradle.publish:plugin-publish-plugin:0.9.3"
+        classpath 'com.netflix.nebula:gradle-lint-plugin:latest.release'
     }
 }
 
@@ -20,6 +21,7 @@ apply plugin: 'groovy'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'nexus'
+apply plugin: 'nebula.lint'
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
@@ -51,7 +53,7 @@ dependencies {
         exclude(module: 'groovy')
     }
 
-    compile('org.jenkins-ci.plugins:job-dsl-core:1.43') {
+    compile('org.jenkins-ci.plugins:job-dsl-core:1.44') {
         exclude(module: 'groovy-all')
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,23 +5,21 @@ buildscript {
             url 'http://repo.jenkins-ci.org/releases/'
         }
         maven {
-            url "https://plugins.gradle.org/m2/"
+            url 'https://plugins.gradle.org/m2/'
         }
     }
 
     dependencies {
         classpath 'org.gradle.api.plugins:gradle-nexus-plugin:0.7'
-        classpath "com.gradle.publish:plugin-publish-plugin:0.9.3"
-        classpath 'com.netflix.nebula:gradle-lint-plugin:latest.release'
+        classpath 'com.gradle.publish:plugin-publish-plugin:0.9.3'
     }
 }
 
-apply plugin: "com.gradle.plugin-publish"
+apply plugin: 'com.gradle.plugin-publish'
 apply plugin: 'groovy'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'nexus'
-apply plugin: 'nebula.lint'
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6

--- a/build.gradle
+++ b/build.gradle
@@ -49,11 +49,13 @@ dependencies {
         'xmlunit:xmlunit:1.3'
     )
 
+    compile('org.jenkins-ci:version-number:1.1')
+
     compile('org.codehaus.groovy.modules.http-builder:http-builder:0.7.2') {
         exclude(module: 'groovy')
     }
 
-    compile('org.jenkins-ci.plugins:job-dsl-core:1.46') {
+    compile('org.jenkins-ci.plugins:job-dsl-core:1.50') {
         exclude(module: 'groovy-all')
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
         exclude(module: 'groovy')
     }
 
-    compile('org.jenkins-ci.plugins:job-dsl-core:1.44') {
+    compile('org.jenkins-ci.plugins:job-dsl-core:1.46') {
         exclude(module: 'groovy-all')
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.3.2
+version=1.3.3
 group=com.terrafolio

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/jobdsl/MapJobManagement.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/jobdsl/MapJobManagement.groovy
@@ -69,11 +69,6 @@ class MapJobManagement extends AbstractJobManagement {
     }
 
     @Override
-    VersionNumber getPluginVersion(String pluginShortName){
-        return null
-    }
-
-    @Override
     Integer getVSphereCloudHash(String name){
         return null
     }
@@ -123,11 +118,6 @@ class MapJobManagement extends AbstractJobManagement {
 
     @Override
     void requireMinimumCoreVersion(String version) { }
-
-    @Override
-    VersionNumber getJenkinsVersion() {
-        return null
-    }
 
     @Override
     Set<String> getPermissions(String authorizationMatrixPropertyClassName) {

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/jobdsl/MapJobManagement.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/jobdsl/MapJobManagement.groovy
@@ -10,7 +10,7 @@ import javaposse.jobdsl.dsl.JobConfigurationNotFoundException
 import javaposse.jobdsl.dsl.NameNotProvidedException
 import hudson.util.VersionNumber
 import javaposse.jobdsl.dsl.UserContent
-import javaposse.jobdsl.dsl.helpers.ExtensibleContext
+import javaposse.jobdsl.dsl.ExtensibleContext
 
 /**
  * Created by ghale on 4/6/14.
@@ -30,7 +30,6 @@ class MapJobManagement extends AbstractJobManagement {
         return map.get(jobName)
     }
 
-    @Override
     boolean createOrUpdateConfig(String jobName, String config, boolean ignoreExisting) throws NameNotProvidedException, ConfigurationMissingException {
         validateUpdateArgs(jobName, config)
         map.put(jobName, config)

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/service/JenkinsRESTServiceImpl.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/service/JenkinsRESTServiceImpl.groovy
@@ -1,5 +1,6 @@
 package com.terrafolio.gradle.plugins.jenkins.service
 
+import com.google.common.annotations.VisibleForTesting
 import groovy.xml.StreamingMarkupBuilder
 import groovyx.net.http.HttpResponseException
 import groovyx.net.http.RESTClient
@@ -20,6 +21,10 @@ class JenkinsRESTServiceImpl implements JenkinsService {
 
     public JenkinsRESTServiceImpl(String url) {
         this.url = url
+    }
+
+    @VisibleForTesting
+    public JenkinsRESTServiceImpl() {
     }
 
     def getRestClient() {

--- a/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/JobDSLSupportTest.groovy
+++ b/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/JobDSLSupportTest.groovy
@@ -19,14 +19,6 @@ class JobDSLSupportTest extends TempDirSpec {
         support = new JobDSLSupport(mockJobManagement)
     }
 
-    def "addConfig adds a config to JobManagement" () {
-        when:
-        support.addConfig("test", "XXX")
-
-        then:
-        1 * mockJobManagement.createOrUpdateConfig("test", "XXX", true)
-    }
-
     def "getConfig returns a config from JobManagement" () {
         when:
         support.getConfig("test")


### PR DESCRIPTION
I've pulled in the patch from @philbert and updated upon his changes to 1.50.

Unit tests ran through with 100% success, however, I don't know how I can fix the integration tests, I always see

```
java.lang.NullPointerException: Cannot invoke method replaceAll() on null object
    at com.terrafolio.gradle.plugins.jenkins.integTest.AbstractJenkinsIntegrationTest.setup(AbstractJenkinsIntegrationTest.groovy:15)
```

and I have no idea how I can give it the needed `jenkins.plugin` property. My naive attempt to use

```
gradle check -Djenkins.plugin=build/libs/gradle-jenkins-plugin-1.3.3.jar
```

failed obviously. 
