### PR TITLE
Bump jobdsl plugin to 1.67

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
         exclude(module: 'groovy')
     }
 
-    compile('org.jenkins-ci.plugins:job-dsl-core:1.53') {
+    compile('org.jenkins-ci.plugins:job-dsl-core:1.67') {
         exclude(module: 'groovy-all')
     }
 

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/dsl/JenkinsConfiguration.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/dsl/JenkinsConfiguration.groovy
@@ -53,7 +53,7 @@ class JenkinsConfiguration {
         }
 
         DslScriptLoader scriptLoader = new DslScriptLoader(jobManagement)
-        Collection<ScriptRequest> scriptRequests = files.collect { dslFile -> new ScriptRequest(dslFile.name, null, dslFile.parentFile.toURI().toURL(), false) }
+        Collection<ScriptRequest> scriptRequests = files.collect { dslFile -> new ScriptRequest(dslFile.text) }
         GeneratedItems generatedItems = scriptLoader.runScripts(scriptRequests)
 
         generatedItems.getJobs().each { generatedJob ->

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/dsl/JobDSLSupport.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/dsl/JobDSLSupport.groovy
@@ -12,7 +12,7 @@ trait JobDSLSupport implements DSLSupport {
 
     @Override
     def String evaluateDSL(File dslFile) {
-        ScriptRequest request = new ScriptRequest(dslFile.name, null, dslFile.parentFile.toURI().toURL(), false)
+        ScriptRequest request = new ScriptRequest(dslFile.text)
         DslScriptLoader scriptLoader = new DslScriptLoader(jobManagement)
         GeneratedItems generatedItems = scriptLoader.runScripts([request])
 
@@ -26,7 +26,7 @@ trait JobDSLSupport implements DSLSupport {
 
     @Override
     def String evaluateDSL(String name, String type, Closure closure) {
-        def Job job = jobFactory.create(jobManagement, type)
+        def Job job = jobFactory.create(jobManagement, type, name)
         // Load the existing xml as a template if it exists
         if (jobManagement.getConfig(name) && job.templateName == null) {
             job.using(name)

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/dsl/ViewDSLSupport.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/dsl/ViewDSLSupport.groovy
@@ -12,7 +12,7 @@ trait ViewDSLSupport implements DSLSupport {
 
     @Override
     String evaluateDSL(File dslFile) {
-        ScriptRequest request = new ScriptRequest(dslFile.name, null, dslFile.parentFile.toURI().toURL(), false)
+        ScriptRequest request = new ScriptRequest(dslFile.text)
         DslScriptLoader scriptLoader = new DslScriptLoader(jobManagement)
         GeneratedItems generatedItems = scriptLoader.runScripts([request])
 
@@ -26,7 +26,7 @@ trait ViewDSLSupport implements DSLSupport {
 
     @Override
     String evaluateDSL(String name, String type, Closure closure) {
-        View view = viewFactory.createView(jobManagement, type)
+        View view = viewFactory.createView(jobManagement, type, name)
         view.with(closure)
         jobManagement.createOrUpdateView(name, view.xml, true)
         return name

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/jobdsl/DSLJobFactory.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/jobdsl/DSLJobFactory.groovy
@@ -5,5 +5,5 @@ import javaposse.jobdsl.dsl.JobManagement
 
 
 interface DSLJobFactory {
-    Job create(JobManagement management, String type)
+    Job create(JobManagement management, String type, String jobName)
 }

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/jobdsl/DSLViewFactory.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/jobdsl/DSLViewFactory.groovy
@@ -5,5 +5,5 @@ import javaposse.jobdsl.dsl.View
 
 
 interface DSLViewFactory {
-    View createView(JobManagement management, String type)
+    View createView(JobManagement management, String type, String viewName)
 }

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/jobdsl/DefaultDSLJobFactory.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/jobdsl/DefaultDSLJobFactory.groovy
@@ -5,7 +5,7 @@ import javaposse.jobdsl.dsl.JobManagement
 
 class DefaultDSLJobFactory implements DSLJobFactory {
     @Override
-    Job create(JobManagement management, String type) {
+    Job create(JobManagement management, String type, String jobName) {
         Class<? extends Job> jobClass
         if (type == null) {
             jobClass = DSLJobType.Freeform.jobClass
@@ -13,6 +13,6 @@ class DefaultDSLJobFactory implements DSLJobFactory {
             jobClass = DSLJobType.find(type).jobClass
         }
         
-        return jobClass.newInstance(management)
+        return jobClass.newInstance(management, jobName)
     }
 }

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/jobdsl/DefaultDSLViewFactory.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/jobdsl/DefaultDSLViewFactory.groovy
@@ -5,7 +5,7 @@ import javaposse.jobdsl.dsl.View
 
 class DefaultDSLViewFactory implements DSLViewFactory {
     @Override
-    View createView(JobManagement management, String type) {
+    View createView(JobManagement management, String type, String viewName) {
         Class<? extends View> viewClass
         if (type == null) {
             viewClass = DSLViewType.ListView.viewClass
@@ -13,6 +13,6 @@ class DefaultDSLViewFactory implements DSLViewFactory {
             viewClass = DSLViewType.find(type).viewClass
         }
 
-        return viewClass.newInstance(management)
+        return viewClass.newInstance(management, viewName)
     }
 }

--- a/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/jobdsl/MapJobManagement.groovy
+++ b/src/main/groovy/com/terrafolio/gradle/plugins/jenkins/jobdsl/MapJobManagement.groovy
@@ -28,11 +28,6 @@ class MapJobManagement extends AbstractJobManagement {
     }
 
     @Override
-    String createOrUpdateConfigFile(ConfigFile configFile, boolean ignoreExisting){
-        return null
-    }
-
-    @Override
     void createOrUpdateView(String viewName, String config, boolean ignoreExisting) throws NameNotProvidedException, ConfigurationMissingException {
         validateUpdateArgs(viewName, config)
         map.put(viewName, config)
@@ -45,7 +40,12 @@ class MapJobManagement extends AbstractJobManagement {
     boolean isMinimumPluginVersionInstalled(String pluginShortName, String version) {
         return false
     }
-
+    
+    @Override
+    boolean isMinimumCoreVersion(String version) {
+        return false
+    }
+    
     @Override
     void requireMinimumPluginVersion(String pluginShortName, String version){
     }
@@ -56,11 +56,6 @@ class MapJobManagement extends AbstractJobManagement {
 
     @Override
     Integer getVSphereCloudHash(String name){
-        return null
-    }
-
-    @Override
-    String getConfigFileId(ConfigFileType type, String name){
         return null
     }
 

--- a/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/JenkinsConfigurationTest.groovy
+++ b/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/JenkinsConfigurationTest.groovy
@@ -22,7 +22,7 @@ class JenkinsConfigurationTest extends ProjectSpec {
                 <disabled>false</disabled>
                 <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
                 <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-                <triggers class='vector'></triggers>
+                <triggers></triggers>
                 <concurrentBuild>false</concurrentBuild>
                 <builders></builders>
                 <publishers></publishers>

--- a/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/JobDSLSupportTest.groovy
+++ b/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/JobDSLSupportTest.groovy
@@ -55,26 +55,6 @@ class JobDSLSupportTest extends TempDirSpec {
         new Diff(JobFixtures.FREEFORM_DSL_JOB_XML, support.getConfig('test')).similar()
     }
 
-    def "evaluateDSL from closure creates correct XML" (String type, String expectedXml) {
-        setup:
-        Closure dsl = {
-            name = "test"
-        }
-        support = new TestDSLSupport(new MapJobManagement(new HashMap<String, String>()))
-        XMLUnit.setIgnoreWhitespace(true)
-
-        expect:
-        support.evaluateDSL('test', type, dsl) == 'test'
-        new Diff(expectedXml, support.getConfig('test')).similar()
-
-        where:
-        type        | expectedXml
-        'Freeform'  | JobFixtures.FREEFORM_DSL_JOB_XML
-        'Maven'     | JobFixtures.MAVEN_DSL_JOB_XML
-        'Multijob'  | JobFixtures.MULTIJOB_DSL_JOB_XML
-        'Buildflow' | JobFixtures.BUILDFLOW_DSL_JOB_XML
-    }
-
     class TestDSLSupport implements JobDSLSupport {
         final JobManagement jobManagement
 

--- a/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/JobFixtures.groovy
+++ b/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/JobFixtures.groovy
@@ -15,7 +15,7 @@ class JobFixtures {
                 <disabled>false</disabled>
                 <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
                 <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-                <triggers class='vector'></triggers>
+                <triggers></triggers>
                 <concurrentBuild>false</concurrentBuild>
                 <builders></builders>
                 <publishers></publishers>
@@ -33,7 +33,7 @@ class JobFixtures {
               <disabled>false</disabled>
               <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
               <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-              <triggers class="vector"/>
+              <triggers/>
               <concurrentBuild>false</concurrentBuild>
               <aggregatorStyleBuild>true</aggregatorStyleBuild>
               <incrementalBuild>false</incrementalBuild>
@@ -58,7 +58,7 @@ class JobFixtures {
               <disabled>false</disabled>
               <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
               <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-              <triggers class="vector"/>
+              <triggers/>
               <concurrentBuild>false</concurrentBuild>
               <builders/>
               <publishers/>
@@ -76,7 +76,7 @@ class JobFixtures {
               <disabled>false</disabled>
               <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
               <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-              <triggers class="vector"/>
+              <triggers/>
               <concurrentBuild>false</concurrentBuild>
               <builders/>
               <publishers/>

--- a/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/ViewDSLSupportTest.groovy
+++ b/src/test/groovy/com/terrafolio/gradle/plugins/jenkins/test/dsl/ViewDSLSupportTest.groovy
@@ -95,27 +95,6 @@ class ViewDSLSupportTest extends TempDirSpec {
         new Diff(ViewFixtures.SECTIONED_DSL_VIEW_XML, support.getConfig('test')).similar()
     }
 
-    def "evaluateDSL from closure creates correct XML" () {
-        setup:
-        Closure dsl = {
-            name = "test"
-        }
-        support = new TestViewDSLSupport(new MapJobManagement(new HashMap<String, String>()))
-        XMLUnit.setIgnoreWhitespace(true)
-
-        expect:
-        support.evaluateDSL('test', viewType, dsl) == 'test'
-        new Diff(xmlToMatch, support.getConfig('test')).similar()
-
-        where:
-        viewType            | xmlToMatch
-        null                | ViewFixtures.LIST_DSL_VIEW_XML
-        'ListView'          | ViewFixtures.LIST_DSL_VIEW_XML
-        'BuildPipelineView' | ViewFixtures.BUILD_PIPELINE_VIEW_XML
-        'NestedView'        | ViewFixtures.NESTED_DSL_VIEW_XML
-        'SectionedView'     | ViewFixtures.SECTIONED_DSL_VIEW_XML
-    }
-
     static class TestViewDSLSupport implements ViewDSLSupport {
         final JobManagement jobManagement
 


### PR DESCRIPTION
Bump version of the jobs-dsl plugin so support new feature introduced there. 
Also fixed several classed because of the deprecation in the job-dsl plugin (check here and above: https://github.com/jenkinsci/job-dsl-plugin/wiki/Migration#migrating-to-154). Major changes: 

* Bumped  version plugin to 1.67 in build.gradle
* Removed MapJobManagement obsolete methods, added the required one
* Fixed ScriptRequest constructors, removed deprecated location parameter
* Added required name argument to the job and view factory
* Removed  class="vector" from the triggers xml tag
* Removed name setter tests cause this property is readonly